### PR TITLE
Add standalone nutrition tracker web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# ern-rungstracker
+# Ernährungstracker
+
+Eine einfache, rein clientseitige Web-App, mit der du deine täglichen Mahlzeiten
+inklusive Kalorien und Makronährstoffe erfassen kannst. Alle Daten werden lokal
+im Browser gespeichert.
+
+## Nutzung
+
+1. Öffne die Datei `index.html` in deinem Browser.
+2. Füge über das Formular neue Lebensmittel hinzu. Neben dem Namen kannst du
+   Kalorien sowie Eiweiß-, Kohlenhydrat- und Fettwerte erfassen.
+3. Wähle im Bereich "Tagesübersicht" das gewünschte Datum, um dessen Einträge
+   und Summen anzuzeigen.
+4. Über die Buttons in der Tabelle lassen sich vorhandene Einträge bearbeiten
+   oder löschen.
+
+## Funktionen
+
+- Tagesbasierte Übersicht mit Summen der Makronährstoffe
+- Bearbeiten- und Lösch-Dialog für bestehende Einträge
+- Automatisches Speichern in `localStorage`
+- Responsives Layout mit Dark-Mode-Unterstützung

--- a/index.html
+++ b/index.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ernährungstracker</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Ernährungstracker</h1>
+      <p>Behalte deine tägliche Ernährung mit Makronährstoffen im Blick.</p>
+    </header>
+
+    <main class="app-content">
+      <section class="tracker-panel" aria-labelledby="tracker-heading">
+        <h2 id="tracker-heading">Eintrag hinzufügen</h2>
+        <form id="entry-form" class="entry-form" autocomplete="off">
+          <div class="form-group">
+            <label for="entry-date">Datum</label>
+            <input type="date" id="entry-date" name="date" required />
+          </div>
+          <div class="form-group">
+            <label for="entry-name">Lebensmittel</label>
+            <input
+              type="text"
+              id="entry-name"
+              name="name"
+              placeholder="z.&nbsp;B. Haferflocken"
+              required
+            />
+          </div>
+          <div class="form-group">
+            <label for="entry-calories">Kalorien (kcal)</label>
+            <input
+              type="number"
+              id="entry-calories"
+              name="calories"
+              min="0"
+              step="1"
+              required
+            />
+          </div>
+          <div class="macro-grid">
+            <div class="form-group">
+              <label for="entry-protein">Eiweiß (g)</label>
+              <input
+                type="number"
+                id="entry-protein"
+                name="protein"
+                min="0"
+                step="0.1"
+                required
+              />
+            </div>
+            <div class="form-group">
+              <label for="entry-carbs">Kohlenhydrate (g)</label>
+              <input
+                type="number"
+                id="entry-carbs"
+                name="carbs"
+                min="0"
+                step="0.1"
+                required
+              />
+            </div>
+            <div class="form-group">
+              <label for="entry-fat">Fett (g)</label>
+              <input
+                type="number"
+                id="entry-fat"
+                name="fat"
+                min="0"
+                step="0.1"
+                required
+              />
+            </div>
+          </div>
+          <button type="submit" class="primary-button">Eintrag speichern</button>
+        </form>
+      </section>
+
+      <section class="summary-panel" aria-labelledby="summary-heading">
+        <div class="summary-header">
+          <h2 id="summary-heading">Tagesübersicht</h2>
+          <div class="summary-date-picker">
+            <label class="sr-only" for="summary-date">Datum auswählen</label>
+            <input type="date" id="summary-date" />
+          </div>
+        </div>
+        <div class="summary-cards" role="status" aria-live="polite">
+          <article class="summary-card">
+            <h3>Kalorien</h3>
+            <p id="total-calories">0</p>
+          </article>
+          <article class="summary-card">
+            <h3>Eiweiß</h3>
+            <p id="total-protein">0&nbsp;g</p>
+          </article>
+          <article class="summary-card">
+            <h3>Kohlenhydrate</h3>
+            <p id="total-carbs">0&nbsp;g</p>
+          </article>
+          <article class="summary-card">
+            <h3>Fett</h3>
+            <p id="total-fat">0&nbsp;g</p>
+          </article>
+        </div>
+
+        <div class="table-container" aria-live="polite">
+          <table class="entries-table">
+            <thead>
+              <tr>
+                <th scope="col">Lebensmittel</th>
+                <th scope="col">Kalorien</th>
+                <th scope="col">Eiweiß</th>
+                <th scope="col">Kohlenhydrate</th>
+                <th scope="col">Fett</th>
+                <th scope="col" class="actions-header">Aktionen</th>
+              </tr>
+            </thead>
+            <tbody id="entries-body">
+              <tr class="empty-row">
+                <td colspan="6">Noch keine Einträge für dieses Datum</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <footer class="app-footer">
+      <p>
+        Deine Daten werden ausschließlich lokal im Browser gespeichert.
+        Aktualisiere die Seite, um neue Tage zu erfassen oder bestehende Einträge
+        zu bearbeiten.
+      </p>
+    </footer>
+
+    <template id="entry-row-template">
+      <tr>
+        <th scope="row" data-field="name"></th>
+        <td data-field="calories"></td>
+        <td data-field="protein"></td>
+        <td data-field="carbs"></td>
+        <td data-field="fat"></td>
+        <td class="entry-actions">
+          <button type="button" class="ghost-button" data-action="edit">Bearbeiten</button>
+          <button type="button" class="ghost-button" data-action="delete">Löschen</button>
+        </td>
+      </tr>
+    </template>
+
+    <dialog id="edit-dialog" aria-labelledby="edit-dialog-title">
+      <form method="dialog" id="edit-form" class="edit-form">
+        <h2 id="edit-dialog-title">Eintrag bearbeiten</h2>
+        <input type="hidden" id="edit-id" />
+        <div class="form-group">
+          <label for="edit-name">Lebensmittel</label>
+          <input type="text" id="edit-name" required />
+        </div>
+        <div class="form-group">
+          <label for="edit-calories">Kalorien (kcal)</label>
+          <input type="number" id="edit-calories" min="0" step="1" required />
+        </div>
+        <div class="macro-grid">
+          <div class="form-group">
+            <label for="edit-protein">Eiweiß (g)</label>
+            <input type="number" id="edit-protein" min="0" step="0.1" required />
+          </div>
+          <div class="form-group">
+            <label for="edit-carbs">Kohlenhydrate (g)</label>
+            <input type="number" id="edit-carbs" min="0" step="0.1" required />
+          </div>
+          <div class="form-group">
+            <label for="edit-fat">Fett (g)</label>
+            <input type="number" id="edit-fat" min="0" step="0.1" required />
+          </div>
+        </div>
+        <menu class="dialog-actions">
+          <button type="button" class="ghost-button" value="cancel">Abbrechen</button>
+          <button type="submit" class="primary-button">Speichern</button>
+        </menu>
+      </form>
+    </dialog>
+
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,225 @@
+const STORAGE_KEY = 'nutrition-tracker-entries';
+const entryForm = document.getElementById('entry-form');
+const editDialog = document.getElementById('edit-dialog');
+const editForm = document.getElementById('edit-form');
+const summaryDateInput = document.getElementById('summary-date');
+const entryDateInput = document.getElementById('entry-date');
+const entriesBody = document.getElementById('entries-body');
+const totals = {
+  calories: document.getElementById('total-calories'),
+  protein: document.getElementById('total-protein'),
+  carbs: document.getElementById('total-carbs'),
+  fat: document.getElementById('total-fat'),
+};
+
+let entries = [];
+let selectedDate = new Date().toISOString().slice(0, 10);
+
+function loadEntries() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        entries = parsed;
+      }
+    }
+  } catch (error) {
+    console.error('Konnte gespeicherte Daten nicht laden:', error);
+    entries = [];
+  }
+}
+
+function saveEntries() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+}
+
+function formatNumber(value, decimals = 0) {
+  return Number(value).toLocaleString('de-DE', {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}
+
+function clearTable() {
+  entriesBody.innerHTML = '';
+}
+
+function showEmptyState() {
+  const row = document.createElement('tr');
+  row.className = 'empty-row';
+  const cell = document.createElement('td');
+  cell.colSpan = 6;
+  cell.textContent = 'Noch keine Einträge für dieses Datum';
+  row.append(cell);
+  entriesBody.append(row);
+}
+
+function renderEntries() {
+  clearTable();
+  const filtered = entries.filter((entry) => entry.date === selectedDate);
+
+  if (!filtered.length) {
+    showEmptyState();
+  } else {
+    const template = document.getElementById('entry-row-template');
+    filtered
+      .sort((a, b) => a.name.localeCompare(b.name, 'de'))
+      .forEach((entry) => {
+        const clone = template.content.firstElementChild.cloneNode(true);
+        clone.dataset.id = entry.id;
+        clone.querySelector('[data-field="name"]').textContent = entry.name;
+        clone.querySelector('[data-field="calories"]').textContent = `${formatNumber(
+          entry.calories,
+        )} kcal`;
+        clone.querySelector('[data-field="protein"]').textContent = `${formatNumber(
+          entry.protein,
+          1,
+        )} g`;
+        clone.querySelector('[data-field="carbs"]').textContent = `${formatNumber(
+          entry.carbs,
+          1,
+        )} g`;
+        clone.querySelector('[data-field="fat"]').textContent = `${formatNumber(
+          entry.fat,
+          1,
+        )} g`;
+        entriesBody.append(clone);
+      });
+  }
+
+  updateTotals(filtered);
+}
+
+function updateTotals(filteredEntries) {
+  const totalsData = filteredEntries.reduce(
+    (acc, entry) => {
+      acc.calories += Number(entry.calories) || 0;
+      acc.protein += Number(entry.protein) || 0;
+      acc.carbs += Number(entry.carbs) || 0;
+      acc.fat += Number(entry.fat) || 0;
+      return acc;
+    },
+    { calories: 0, protein: 0, carbs: 0, fat: 0 },
+  );
+
+  totals.calories.textContent = formatNumber(totalsData.calories);
+  totals.protein.innerHTML = `${formatNumber(totalsData.protein, 1)}&nbsp;g`;
+  totals.carbs.innerHTML = `${formatNumber(totalsData.carbs, 1)}&nbsp;g`;
+  totals.fat.innerHTML = `${formatNumber(totalsData.fat, 1)}&nbsp;g`;
+}
+
+function resetForm() {
+  entryForm.reset();
+  entryDateInput.value = selectedDate;
+}
+
+function handleFormSubmit(event) {
+  event.preventDefault();
+  const formData = new FormData(entryForm);
+  const newEntry = {
+    id: crypto.randomUUID(),
+    date: formData.get('date'),
+    name: formData.get('name').trim(),
+    calories: Number(formData.get('calories')),
+    protein: Number(formData.get('protein')),
+    carbs: Number(formData.get('carbs')),
+    fat: Number(formData.get('fat')),
+  };
+
+  entries.push(newEntry);
+  saveEntries();
+  renderEntries();
+  resetForm();
+  entryForm.elements.name.focus();
+}
+
+function openEditDialog(entry) {
+  document.getElementById('edit-id').value = entry.id;
+  document.getElementById('edit-name').value = entry.name;
+  document.getElementById('edit-calories').value = entry.calories;
+  document.getElementById('edit-protein').value = entry.protein;
+  document.getElementById('edit-carbs').value = entry.carbs;
+  document.getElementById('edit-fat').value = entry.fat;
+  editDialog.showModal();
+}
+
+function handleEditSubmit(event) {
+  event.preventDefault();
+  const id = document.getElementById('edit-id').value;
+  const entryIndex = entries.findIndex((item) => item.id === id);
+  if (entryIndex === -1) return;
+
+  entries[entryIndex] = {
+    ...entries[entryIndex],
+    name: document.getElementById('edit-name').value.trim(),
+    calories: Number(document.getElementById('edit-calories').value),
+    protein: Number(document.getElementById('edit-protein').value),
+    carbs: Number(document.getElementById('edit-carbs').value),
+    fat: Number(document.getElementById('edit-fat').value),
+  };
+
+  saveEntries();
+  renderEntries();
+  editDialog.close();
+}
+
+function deleteEntry(id) {
+  const confirmed = confirm('Möchtest du diesen Eintrag wirklich löschen?');
+  if (!confirmed) return;
+
+  entries = entries.filter((entry) => entry.id !== id);
+  saveEntries();
+  renderEntries();
+}
+
+function handleTableClick(event) {
+  const actionButton = event.target.closest('button[data-action]');
+  if (!actionButton) return;
+
+  const row = actionButton.closest('tr');
+  const id = row?.dataset.id;
+  if (!id) return;
+
+  const entry = entries.find((item) => item.id === id);
+  if (!entry) return;
+
+  if (actionButton.dataset.action === 'edit') {
+    openEditDialog(entry);
+  } else if (actionButton.dataset.action === 'delete') {
+    deleteEntry(id);
+  }
+}
+
+function initializeDates() {
+  entryDateInput.value = selectedDate;
+  summaryDateInput.value = selectedDate;
+}
+
+function handleSummaryDateChange(event) {
+  selectedDate = event.target.value || selectedDate;
+  entryDateInput.value = selectedDate;
+  renderEntries();
+}
+
+function handleDialogCancel(event) {
+  event.preventDefault();
+  editDialog.close();
+}
+
+function setupEventListeners() {
+  entryForm.addEventListener('submit', handleFormSubmit);
+  editForm.addEventListener('submit', handleEditSubmit);
+  editForm.querySelector('button[value="cancel"]').addEventListener('click', handleDialogCancel);
+  summaryDateInput.addEventListener('change', handleSummaryDateChange);
+  entriesBody.addEventListener('click', handleTableClick);
+}
+
+function init() {
+  loadEntries();
+  initializeDates();
+  renderEntries();
+  setupEventListeners();
+}
+
+window.addEventListener('DOMContentLoaded', init);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,356 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  background-color: #f5f5f7;
+  color: #1f2933;
+  --panel-bg: #ffffffcc;
+  --panel-border: #d2d6dc;
+  --accent: #2563eb;
+  --accent-dark: #1d4ed8;
+  --shadow: 0 20px 50px -25px rgba(15, 23, 42, 0.5);
+  --radius: 18px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #e0ecff, #f5f5f7 55%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 48px 16px 32px;
+  gap: 32px;
+}
+
+.app-header,
+.app-footer {
+  max-width: 1100px;
+  width: 100%;
+  text-align: center;
+  background: var(--panel-bg);
+  backdrop-filter: blur(18px);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius);
+  padding: 24px;
+  box-shadow: var(--shadow);
+}
+
+.app-header h1 {
+  margin: 0 0 8px;
+  font-size: clamp(2rem, 3vw + 1rem, 3rem);
+}
+
+.app-header p {
+  margin: 0;
+  color: #52616b;
+  font-weight: 500;
+}
+
+.app-content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
+  width: 100%;
+  max-width: 1100px;
+}
+
+.tracker-panel,
+.summary-panel {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius);
+  padding: 32px;
+  backdrop-filter: blur(18px);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.tracker-panel h2,
+.summary-panel h2 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.entry-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.form-group label {
+  font-weight: 600;
+  color: #334155;
+}
+
+.form-group input {
+  border: 1px solid #cbd5f5;
+  border-radius: 12px;
+  padding: 12px 14px;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-group input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+}
+
+.macro-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.primary-button,
+.ghost-button {
+  font-size: 1rem;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease,
+    color 0.2s ease;
+}
+
+.primary-button {
+  border: none;
+  padding: 14px 18px;
+  background: linear-gradient(135deg, var(--accent), var(--accent-dark));
+  color: #fff;
+  font-weight: 600;
+  box-shadow: 0 12px 25px -12px rgba(37, 99, 235, 0.8);
+}
+
+.primary-button:hover,
+.primary-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px -12px rgba(37, 99, 235, 0.9);
+}
+
+.primary-button:active {
+  transform: translateY(0);
+  box-shadow: 0 8px 20px -12px rgba(37, 99, 235, 0.9);
+}
+
+.ghost-button {
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--accent);
+  padding: 10px 14px;
+  font-weight: 600;
+}
+
+.ghost-button:hover,
+.ghost-button:focus-visible {
+  color: #0f172a;
+  border-color: rgba(37, 99, 235, 0.2);
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.summary-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.summary-date-picker input {
+  border: 1px solid #cbd5f5;
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-size: 1rem;
+}
+
+.summary-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 16px;
+}
+
+.summary-card {
+  border-radius: 16px;
+  padding: 20px;
+  background: rgba(37, 99, 235, 0.08);
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.summary-card h3 {
+  margin: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #1d4ed8;
+}
+
+.summary-card p {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.table-container {
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+.entries-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.entries-table th,
+.entries-table td {
+  padding: 14px 18px;
+  text-align: left;
+}
+
+.entries-table thead {
+  background: rgba(15, 23, 42, 0.05);
+  font-weight: 600;
+  color: #475569;
+}
+
+.entries-table tbody tr:nth-child(even) {
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.entries-table tbody tr:hover {
+  background: rgba(37, 99, 235, 0.1);
+}
+
+.entries-table td[data-field] {
+  font-variant-numeric: tabular-nums;
+}
+
+.entries-table .actions-header,
+.entries-table .entry-actions {
+  text-align: right;
+}
+
+.entries-table .entry-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.entries-table .ghost-button {
+  padding: 6px 10px;
+  font-size: 0.95rem;
+}
+
+.empty-row td {
+  text-align: center;
+  padding: 32px;
+  color: #64748b;
+}
+
+.app-footer p {
+  margin: 0;
+  color: #52616b;
+  line-height: 1.6;
+}
+
+#edit-dialog {
+  border: none;
+  padding: 0;
+  border-radius: 18px;
+  box-shadow: var(--shadow);
+  max-width: 420px;
+  width: min(90vw, 420px);
+}
+
+.edit-form {
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.edit-form h2 {
+  margin: 0;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+}
+
+.dialog-actions .primary-button,
+.dialog-actions .ghost-button {
+  padding: 10px 14px;
+}
+
+.sr-only {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 24px 12px 24px;
+  }
+
+  .tracker-panel,
+  .summary-panel {
+    padding: 24px;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    background-color: #0f172a;
+    color: #e2e8f0;
+    --panel-bg: rgba(15, 23, 42, 0.75);
+    --panel-border: rgba(148, 163, 184, 0.4);
+    --shadow: 0 24px 60px -32px rgba(2, 6, 23, 0.85);
+  }
+
+  body {
+    background: radial-gradient(circle at top, #1e293b, #0f172a 65%);
+  }
+
+  .app-header p,
+  .app-footer p {
+    color: #cbd5f5;
+  }
+
+  .summary-card {
+    background: rgba(37, 99, 235, 0.12);
+    border-color: rgba(37, 99, 235, 0.3);
+  }
+
+  .entries-table thead {
+    background: rgba(148, 163, 184, 0.12);
+    color: #e2e8f0;
+  }
+
+  .entries-table tbody tr:nth-child(even) {
+    background: rgba(148, 163, 184, 0.16);
+  }
+}


### PR DESCRIPTION
## Summary
- build a responsive nutrition tracker interface with entry form, daily summary, and totals
- add modal editing and deletion workflows with localStorage persistence
- style the app with modern glassmorphism, dark-mode support, and update the README with usage instructions

## Testing
- not run (static web app)


------
https://chatgpt.com/codex/tasks/task_e_68d6f2d234648330b452340e8ff82ec7