### PR TITLE
Add quick date toggles and improve dark mode visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,9 +89,27 @@
       <section class="summary-panel" aria-labelledby="summary-heading">
         <div class="summary-header">
           <h2 id="summary-heading">Tagesübersicht</h2>
-          <div class="summary-date-picker">
-            <label class="sr-only" for="summary-date">Datum auswählen</label>
-            <input type="date" id="summary-date" />
+          <div class="summary-controls">
+            <div class="date-toggle" role="group" aria-label="Schnellauswahl Datum">
+              <button
+                type="button"
+                class="ghost-button"
+                data-date-shortcut="yesterday"
+              >
+                Gestern
+              </button>
+              <button
+                type="button"
+                class="ghost-button"
+                data-date-shortcut="today"
+              >
+                Heute
+              </button>
+            </div>
+            <div class="summary-date-picker">
+              <label class="sr-only" for="summary-date">Datum auswählen</label>
+              <input type="date" id="summary-date" />
+            </div>
           </div>
         </div>
         <div class="summary-cards" role="status" aria-live="polite">

--- a/script.js
+++ b/script.js
@@ -5,6 +5,7 @@ const editForm = document.getElementById('edit-form');
 const summaryDateInput = document.getElementById('summary-date');
 const entryDateInput = document.getElementById('entry-date');
 const entriesBody = document.getElementById('entries-body');
+const dateShortcutButtons = document.querySelectorAll('[data-date-shortcut]');
 const totals = {
   calories: document.getElementById('total-calories'),
   protein: document.getElementById('total-protein'),
@@ -89,6 +90,7 @@ function renderEntries() {
   }
 
   updateTotals(filtered);
+  updateDateShortcutState();
 }
 
 function updateTotals(filteredEntries) {
@@ -112,6 +114,7 @@ function updateTotals(filteredEntries) {
 function resetForm() {
   entryForm.reset();
   entryDateInput.value = selectedDate;
+  summaryDateInput.value = selectedDate;
 }
 
 function handleFormSubmit(event) {
@@ -197,9 +200,13 @@ function initializeDates() {
 }
 
 function handleSummaryDateChange(event) {
-  selectedDate = event.target.value || selectedDate;
-  entryDateInput.value = selectedDate;
-  renderEntries();
+  const newDate = event.target.value;
+  if (!newDate) {
+    summaryDateInput.value = selectedDate;
+    return;
+  }
+
+  setSelectedDate(newDate);
 }
 
 function handleDialogCancel(event) {
@@ -215,11 +222,57 @@ function setupEventListeners() {
   entriesBody.addEventListener('click', handleTableClick);
 }
 
+function updateDateShortcutState() {
+  dateShortcutButtons.forEach((button) => {
+    const value = button.dataset.dateValue;
+    button.classList.toggle('is-active', value === selectedDate);
+  });
+}
+
+function setSelectedDate(newDate) {
+  selectedDate = newDate;
+  summaryDateInput.value = selectedDate;
+  entryDateInput.value = selectedDate;
+  renderEntries();
+}
+
+function computeDateShortcuts() {
+  const today = new Date();
+  const todayIso = today.toISOString().slice(0, 10);
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  const yesterdayIso = yesterday.toISOString().slice(0, 10);
+
+  dateShortcutButtons.forEach((button) => {
+    const key = button.dataset.dateShortcut;
+    if (key === 'today') {
+      button.dataset.dateValue = todayIso;
+    } else if (key === 'yesterday') {
+      button.dataset.dateValue = yesterdayIso;
+    }
+  });
+}
+
+function setupDateShortcuts() {
+  dateShortcutButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const value = button.dataset.dateValue;
+      if (value) {
+        setSelectedDate(value);
+      }
+    });
+  });
+
+  updateDateShortcutState();
+}
+
 function init() {
   loadEntries();
+  computeDateShortcuts();
   initializeDates();
   renderEntries();
   setupEventListeners();
+  setupDateShortcuts();
 }
 
 window.addEventListener('DOMContentLoaded', init);

--- a/styles.css
+++ b/styles.css
@@ -29,7 +29,7 @@ body {
 
 .app-header,
 .app-footer {
-  max-width: 1100px;
+  max-width: 1280px;
   width: 100%;
   text-align: center;
   background: var(--panel-bg);
@@ -56,7 +56,7 @@ body {
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 24px;
   width: 100%;
-  max-width: 1100px;
+  max-width: 1280px;
 }
 
 .tracker-panel,
@@ -70,6 +70,43 @@ body {
   display: flex;
   flex-direction: column;
   gap: 24px;
+}
+
+.summary-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.summary-controls {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.date-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(37, 99, 235, 0.1);
+  padding: 4px;
+  border-radius: 14px;
+}
+
+.date-toggle .ghost-button {
+  padding: 8px 14px;
+}
+
+.date-toggle .ghost-button.is-active {
+  background: var(--accent);
+  color: #ffffff;
+  box-shadow: 0 12px 20px -12px rgba(37, 99, 235, 0.8);
+}
+
+.summary-date-picker input[type='date'] {
+  min-width: 200px;
 }
 
 .tracker-panel h2,
@@ -345,6 +382,14 @@ body {
     border-color: rgba(37, 99, 235, 0.3);
   }
 
+  .date-toggle {
+    background: rgba(37, 99, 235, 0.2);
+  }
+
+  .date-toggle .ghost-button.is-active {
+    background: rgba(37, 99, 235, 0.95);
+  }
+
   .entries-table thead {
     background: rgba(148, 163, 184, 0.12);
     color: #e2e8f0;
@@ -352,5 +397,18 @@ body {
 
   .entries-table tbody tr:nth-child(even) {
     background: rgba(148, 163, 184, 0.16);
+  }
+
+  .entries-table th,
+  .entries-table td {
+    color: #f1f5f9;
+  }
+
+  .entries-table td[data-field] {
+    color: #e2e8f0;
+  }
+
+  .empty-row td {
+    color: #cbd5f5;
   }
 }


### PR DESCRIPTION
## Summary
- add today and yesterday shortcut buttons to the summary panel and wire them into the date selection logic
- widen the layout and style the new summary controls for better spacing
- adjust dark mode table colors to keep the entry list legible at night

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6fe3817e4833089a59551eaa9153c